### PR TITLE
Run the views / models script via Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,19 @@ See [data](data).
 
 ## The problems we're trying to solve
 
-*Customer segmentation*: identify groups of customers that have similar attributes relevant for marketing e.g. age, gender, spending habits.
+### Customer segmentation
 
-*Repeat-buyer prediction*: given historical purchases, can we predict which customers will make more than one purchase?
+Identify groups of customers that have similar attributes relevant for marketing e.g. age, gender, spending habits. These groups are linked to lifetime value and annual revenue.
+
+We use a k-means clustering model to do this. This model takes `n` data points and clusters them into `k` clusters, so `k` must be greater than 0 and no larger than `n`. If we only have one cluster, then every customer belongs to the same marketing segment, so that doesn't tell us very much. Similarly, if we have `n` clusters then every customer will have their very own marketing segment, which isn't particularly helpful either.
+
+We want a sensible value for `k` that lies somewhere in-between. See the [customer segmentation jupyter notebook](analysis/customer-segmentation.ipynb) for more details.
+
+### Repeat-buyer prediction
+
+Given historical purchases and related activity, can we predict which customers will make more than one purchase?
+
+See the [repeat buyers jupyter notebook](analysis/repeat-buyers.ipynb) for more details.
 
 ## The analysis
 
@@ -31,7 +41,7 @@ See [data analysis README](analysis/README.md).
 
 ## Provisioning BigQuery
 
-### Loading data into BigQuery
+### Loading data into BigQuery and training models
 
 First of all we need to create the BigQuery [dataset](https://cloud.google.com/bigquery/docs/datasets) and [tables](https://cloud.google.com/bigquery/docs/tables) with an appropriate schema. Once they are created we will [load the data](https://cloud.google.com/bigquery/docs/loading-data-local) into the tables from our local CSV files.
 
@@ -46,19 +56,10 @@ terraform plan
 terraform apply
 ```
 
-### Training a model
-
-Once the data is loaded we can train a BigQuery model to break the customers into segments which helps us identify groups of customers by their age and other attributes. These groups are linked to lifetime value and annual revenue.
-
-We use a k-means clustering model to do this. This model takes `n` data points and clusters them into `k` clusters, so `k` must be greater than 0 and no larger than `n`. If we only have one cluster, then every customer belongs to the same marketing segment, so that doesn't tell us very much. Similarly, if we have `n` clusters then every customer will have their very own marketing segment, which isn't particularly helpful either.
-
-We want a sensible value for `k` that lies somewhere in-between. One approach to this is [Elbow Analysis](https://en.wikipedia.org/wiki/Elbow_method_(clustering)). In Elbow Analysis we train a number of alternative clustering models for various values of `k` and we pick the one that has the best trade-off between how spread out the data within clusters is and the number of clusters.
-
-To generate a series of alternative models:
-
-```
-cd terraform
-./scripts/segmentation-model.sh
-```
+This will do the following:
+  - Create the BigQuery DataSet
+  - Create tables within that DataSet
+  - Load the csv data into the tables, using 'autodetect' for the schema
+  - Create training views and models for both 'Customer Segmentation' and 'Repeat Buyers'
 
 You'll need the Google Cloud SDK installed and to be authenticated with your Google Cloud account to do this.

--- a/bigquery/sql/repeat-buyer-evaluation.sql
+++ b/bigquery/sql/repeat-buyer-evaluation.sql
@@ -1,6 +1,6 @@
 #standardSQL
 
 select * from
-ML.EVALUATE(MODEL `fuzzylabs.sahara_marketing.regression_model`, (
-  select repeat_buyer as label, * from `fuzzylabs.sahara_marketing.regression_training_set`
+ML.EVALUATE(MODEL `fuzzylabs.sahara_marketing.repeat_buyer_model`, (
+  select repeat_buyer as label, * from `fuzzylabs.sahara_marketing.repeat_buyer_training_set`
 ))

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,9 +24,9 @@ resource "google_bigquery_table" "default" {
 }
 
 resource "null_resource" "default" {
-  # Recreate the views and models whenever the size (num_bytes) of any table changes.
+  # Recreate the views and models whenever any of the tables are modified
   triggers = {
-    table_sizes = "${join(",", google_bigquery_table.default.*.num_bytes)}"
+    last_modified_time = "${join(",", google_bigquery_table.default.*.last_modified_time)}"
   }
   provisioner "local-exec" {
     command = "scripts/create-views-models.sh ${var.location} ${var.project} ${var.dataset_id}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,3 +22,13 @@ resource "google_bigquery_table" "default" {
     EOT
   }
 }
+
+resource "null_resource" "default" {
+  # Recreate the views and models whenever the size (num_bytes) of any table changes.
+  triggers = {
+    table_sizes = "${join(",", google_bigquery_table.default.*.num_bytes)}"
+  }
+  provisioner "local-exec" {
+    command = "scripts/create-views-models.sh ${var.location} ${var.project} ${var.dataset_id}"
+  }
+}

--- a/terraform/scripts/create-views-models.sh
+++ b/terraform/scripts/create-views-models.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-# This trains a number of k-means clustering models with different values of k (the number of clusters)
-# We use that to find the optimal value of k by looking for the 'elbow point': https://en.wikipedia.org/wiki/Elbow_method_(clustering)
-#
 # Requirements: Google Cloud SDK (provides 'bq', the BigQuery command-line tool)
 
-LOCATION=europe-west2
-PROJECT=fuzzylabs
-DATASET=sahara_marketing
+LOCATION=${1:-europe-west2}
+PROJECT=${2:-fuzzylabs}
+DATASET=${3:-sahara_marketing}
 
 SED_DATASET=s/__REPLACE_ME__/$PROJECT.$DATASET/g
 

--- a/terraform/scripts/create-views-models.sh
+++ b/terraform/scripts/create-views-models.sh
@@ -2,9 +2,9 @@
 
 # Requirements: Google Cloud SDK (provides 'bq', the BigQuery command-line tool)
 
-LOCATION=${1:-europe-west2}
-PROJECT=${2:-fuzzylabs}
-DATASET=${3:-sahara_marketing}
+LOCATION=$1
+PROJECT=$2
+DATASET=$3
 
 SED_DATASET=s/__REPLACE_ME__/$PROJECT.$DATASET/g
 


### PR DESCRIPTION
Everything is now being run by Terraform. The `create-views-models.sh` script (previously `segmentation-model.sh) is now run using a Terraform `null_resource` type.

Note: that the null_resource is triggered whenever it detects that the sizes of any of the BigQuery tables (created by Terraform) have changed. This allows the script to be run after initial creation of the tables and does not trigger on subsequent Terraform runs unless the tables have changed.

Other Stuff:
  - README updated, references to elbow point removed.
  - `create-views-models.sh` now takes positional arguments (which we pass from Terraform).
  - Fix typo in `sql` script referencing non existent regression items.